### PR TITLE
Update to latest pybind11 for Python 3.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "third_party/pybind11"]
 	path = third_party/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 	branch = v2.8


### PR DESCRIPTION
This library fails to compile on Python 3.11 with error `‘PyCodeObject {aka struct PyCodeObject}’ has no member named ‘co_varnames’; did you mean ‘co_names’?`. Caused due to an ancient pybind11 version. Update to main to fix the issue